### PR TITLE
Fix mismatched numpy versions with bokeh dependencies in vector notebook

### DIFF
--- a/notebooks/vector-analysis-with-sklearn-and-bokeh.ipynb
+++ b/notebooks/vector-analysis-with-sklearn-and-bokeh.ipynb
@@ -43,7 +43,7 @@
       "cell_type": "code",
       "source": [
         "# Install dependencies\n",
-        "!pip install -qqq --upgrade roboflow sklearn pandas numpy bokeh"
+        "!pip install -qqq --upgrade roboflow sklearn pandas bokeh"
       ],
       "metadata": {
         "id": "6Hgaie3mzlWd"


### PR DESCRIPTION
# Description

When running the notebook from scratch, noticed that it was complaining in the Colab environment about mismatched versions of numpy & a run-through from the top wasn't working right.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

In Colab environment.

## Any specific deployment considerations

None

## Docs

-  Not needed, bug fix.
