### PR TITLE
Fixed export instructions for YOLOv8 classification

### DIFF
--- a/notebooks/train-yolov8-classification-on-custom-dataset.ipynb
+++ b/notebooks/train-yolov8-classification-on-custom-dataset.ipynb
@@ -461,7 +461,7 @@
         "\n",
         "### Step 5: Exporting dataset\n",
         "\n",
-        "Once the dataset version is generated, we have a hosted dataset we can load directly into our notebook for easy training. Click `Export` and select the `YOLO v5 PyTorch` dataset format.\n",
+        "Once the dataset version is generated, we have a hosted dataset we can load directly into our notebook for easy training. Click `Export` and select the `Folder Structure` dataset format.\n",
         "\n",
         "<div align=\"center\">\n",
         "  <img\n",


### PR DESCRIPTION
YOLOv8's classification notebook includes a step to export the dataset from Roboflow saying to pick "YOLOv5 PyTorch" which is not valid for this notebook nor a valid option in RF classification dataset exports