### PR TITLE
Call raise_for_status after retrieving a URL with requests

### DIFF
--- a/notebooks/train-yolov5-classification-on-custom-data.ipynb
+++ b/notebooks/train-yolov5-classification-on-custom-data.ipynb
@@ -107,9 +107,10 @@
         "#Download example image\n",
         "import requests\n",
         "image_url = \"https://i.imgur.com/OczPfaz.jpg\"\n",
-        "img_data = requests.get(image_url).content\n",
+        "response = requests.get(image_url)\n",
+        "response.raise_for_status()\n",
         "with open('bananas.jpg', 'wb') as handler:\n",
-        "    handler.write(img_data)"
+        "    handler.write(response.content)"
       ],
       "metadata": {
         "id": "L9objhVHnS-h"

--- a/notebooks/train-yolov5-instance-segmentation-on-custom-data.ipynb
+++ b/notebooks/train-yolov5-instance-segmentation-on-custom-data.ipynb
@@ -384,9 +384,10 @@
         "#Download example image\n",
         "import requests\n",
         "image_url = \"https://i.imgur.com/EbOBS5l.jpg\"\n",
-        "img_data = requests.get(image_url).content\n",
+        "response = requests.get(image_url)\n",
+        "response.raise_for_status()\n",
         "with open(f\"{HOME}/yolov5/data/images/zebra.jpg\", \"wb\") as handler:\n",
-        "    handler.write(img_data)"
+        "    handler.write(response.content)"
       ]
     },
     {
@@ -1627,16 +1628,17 @@
         "#demo. These images are relevant to the ASL Poly dataset. Skip the rest of this\n",
         "#cell if you are providing your own example image directory.\n",
         "os.makedirs(example_image_dir, exist_ok=True)\n",
-        "image_links = [\n",
+        "image_urls = [\n",
         "    \"https://i.imgur.com/rFsDnHC.jpg\", \n",
         "    \"https://i.imgur.com/aEcceXm.jpg\", \n",
         "    \"https://i.imgur.com/s4N63fx.jpg\",\n",
         "    ]\n",
         "\n",
-        "for i,link in enumerate(image_links):\n",
-        "  img_data = requests.get(link).content\n",
-        "  with open(os.path.join(example_image_dir,f'example_{i}.jpg'), 'wb') as handler:\n",
-        "    handler.write(img_data)"
+        "for i, image_url in enumerate(image_urls):\n",
+        "    response = requests.get(image_url)\n",
+        "    response.raise_for_status()\n",
+        "    with open(os.path.join(example_image_dir,f'example_{i}.jpg'), 'wb') as handler:\n",
+        "        handler.write(response.content)"
       ]
     },
     {


### PR DESCRIPTION
# Description

Sometimes, image files may fail to download due to HTTP errors such as "429 Too Many Requests".  As a result of the image file on disk being empty, errors may occur later on in the notebook, which can look somewhat misleading:

cv2.error: OpenCV(4.7.0) /io/opencv/modules/imgcodecs/src/loadsave.cpp:798:
  error: (-215:Assertion failed) !buf.empty() in function 'imdecode_'

Add a call to `raise_for_status()` on the returned `response` object from the `requests` library, which at the very least notifies the user that something has gone wrong.

(Alternately, perhaps consider relocating the images from imgur to some other CDN, or even commit them directly to this repository.)

Also, fix some indentation, spacing, and variable naming inconsistencies.

## Type of change

Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Manually tested running the notebooks, ensuring the 429 error is displayed to the user.

## Any specific deployment considerations

None.

## Docs

No documentation was updated.