### PR TITLE
Fix videos URLs on the tutorial section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Almost every week we create tutorials showing you the hottest models in Computer
 
 <p align="left">
 <a href="https://youtu.be/CilXrt3S-ws" title="How to Choose the Best Computer Vision Model for Your Project"><img src="https://github.com/roboflow/notebooks/assets/26109316/73a01d3b-cf70-40c3-a5e4-e4bc5be38d42" alt="How to Choose the Best Computer Vision Model for Your Project" width="300px" align="left" /></a>
-<a href="hhttps://youtu.be/CilXrt3S-ws" title="How to Choose the Best Computer Vision Model for Your Project"><strong>How to Choose the Best Computer Vision Model for Your Project</strong></a>
+<a href="https://youtu.be/CilXrt3S-ws" title="How to Choose the Best Computer Vision Model for Your Project"><strong>How to Choose the Best Computer Vision Model for Your Project</strong></a>
 <div><strong>Created: 26 May 2023</strong> | <strong>Updated: 26 May 2023</strong></div>
 <br/> In this video, we will dive into the complexity of choosing the right computer vision model for your unique project. From the importance of high-quality datasets to hardware considerations, interoperability, benchmarking, and licensing issues, this video covers it all... </p> <br/>
 
@@ -132,8 +132,8 @@ Almost every week we create tutorials showing you the hottest models in Computer
 <div><strong>Created: 20 Apr 2023</strong> | <strong>Updated: 20 Apr 2023</strong></div>
 <br/> Discover how to speed up your image annotation process using Grounding DINO and Segment Anything Model (SAM). Learn how to convert object detection datasets into instance segmentation datasets, and see the potential of using these models to automatically annotate your datasets for real-time detectors like YOLOv8... </p> <br/>
 <p align="left">
-<a href="https://youtu.be/oEQYStnF2l8" title="SAM - Segment Anything Model by Meta AI: Complete Guide"><img src="https://github.com/SkalskiP/SkalskiP/assets/26109316/6913ff11-53c6-4341-8d90-eaff3023c3fd" alt="SAM - Segment Anything Model by Meta AI: Complete Guide" width="300px" align="left" /></a>
-<a href="https://youtu.be/oEQYStnF2l8" title="SAM - Segment Anything Model by Meta AI: Complete Guide"><strong>SAM - Segment Anything Model by Meta AI: Complete Guide</strong></a>
+<a href="https://youtu.be/D-D6ZmadzPE" title="SAM - Segment Anything Model by Meta AI: Complete Guide"><img src="https://github.com/SkalskiP/SkalskiP/assets/26109316/6913ff11-53c6-4341-8d90-eaff3023c3fd" alt="SAM - Segment Anything Model by Meta AI: Complete Guide" width="300px" align="left" /></a>
+<a href="https://youtu.be/D-D6ZmadzPE" title="SAM - Segment Anything Model by Meta AI: Complete Guide"><strong>SAM - Segment Anything Model by Meta AI: Complete Guide</strong></a>
 <div><strong>Created: 11 Apr 2023</strong> | <strong>Updated: 11 Apr 2023</strong></div>
 
 <br/> Discover the incredible potential of Meta AI's Segment Anything Model (SAM)! We dive into SAM, an efficient and promptable model for image segmentation, which has revolutionized computer vision tasks. With over 1 billion masks on 11M licensed and privacy-respecting images, SAM's zero-shot performance is often superior to prior fully supervised results... </p>


### PR DESCRIPTION
# Description

Fix videos URLs on the tutorial section of README.

## Type of change

-   [x] This change requires a documentation update

Related to: https://github.com/roboflow/supervision/pull/314