### PR TITLE
Add explore more Roboflow open source projects section

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
   </p>
   <br>
 
+  [notebooks](https://github.com/roboflow/notebooks) | [inference](https://github.com/roboflow/inference) | [autodistill](https://github.com/autodistill/autodistill) | [collect](https://github.com/roboflow/roboflow-collect)
+
+  <br>
+
   <div align="center">
       <a href="https://youtube.com/roboflow">
           <img


### PR DESCRIPTION
This PR adds a new standard "explore more Roboflow open source projects" to the project README.

This is a replacement for #193.