### PR TITLE
Use new milk file

### DIFF
--- a/notebooks/dino-gpt4v-autodistill.ipynb
+++ b/notebooks/dino-gpt4v-autodistill.ipynb
@@ -288,7 +288,7 @@
         "%cd {HOME}/videos\n",
         "\n",
         "# download zip file containing videos\n",
-        "!wget --load-cookies /tmp/cookies.txt \"https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1wnW7v6UTJZTAcOQj0416ZbQF8b7yO6Pt' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\\1\\n/p')&id=1wnW7v6UTJZTAcOQj0416ZbQF8b7yO6Pt\" -O milk.zip && rm -rf /tmp/cookies.txt\n",
+        "!wget https://media.roboflow.com/milk.zip\n",
         "\n",
         "# unzip videos\n",
         "!unzip milk.zip"

--- a/notebooks/how-to-auto-train-yolov8-model-with-autodistill.ipynb
+++ b/notebooks/how-to-auto-train-yolov8-model-with-autodistill.ipynb
@@ -298,7 +298,7 @@
         "%cd {HOME}/videos\n",
         "\n",
         "# download zip file containing videos\n",
-        "!wget --load-cookies /tmp/cookies.txt \"https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1wnW7v6UTJZTAcOQj0416ZbQF8b7yO6Pt' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\\1\\n/p')&id=1wnW7v6UTJZTAcOQj0416ZbQF8b7yO6Pt\" -O milk.zip && rm -rf /tmp/cookies.txt\n",
+        "!wget https://media.roboflow.com/milk.zip\n",
         "\n",
         "# unzip videos\n",
         "!unzip milk.zip"


### PR DESCRIPTION
# Description

This PR changes the notebooks that use the milk dataset hosted on Google Drive to use `https://media.roboflow.com/milk.zip`.

The current way of downloading the file is broken, reported by https://github.com/autodistill/autodistill/issues/116 and validated by me.

## Type of change

- [X] Bug fix

## How has this change been tested, please provide a testcase or example of how you tested the change?

You can download the new file with:

```
!wget https://media.roboflow.com
```

## Any specific deployment considerations

N/A

## Docs

N/A