### PR TITLE
Pin numpy version in deprecated notebook

### DIFF
--- a/notebooks/how-to-track-and-count-vehicles-with-yolov8.ipynb
+++ b/notebooks/how-to-track-and-count-vehicles-with-yolov8.ipynb
@@ -240,7 +240,7 @@
         "# workaround related to https://github.com/roboflow/notebooks/issues/80\n",
         "!sed -i 's/onnx==1.8.1/onnx==1.9.0/g' requirements.txt\n",
         "\n",
-        "!pip3 install -q -r requirements.txt\n",
+        "!pip3 install -q 'numpy<1.24' -r requirements.txt\n",
         "!python3 setup.py -q develop\n",
         "!pip install -q cython_bbox\n",
         "!pip install -q onemetric\n",


### PR DESCRIPTION
# Description

Ref #272

Pin numpy version in ByteTracker installation to make the notebook work.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

YOUR_ANSWER

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
