### PR TITLE
Updated Notebooks Link

### DIFF
--- a/notebooks/how-to-finetune-paligemma-on-detection-dataset.ipynb
+++ b/notebooks/how-to-finetune-paligemma-on-detection-dataset.ipynb
@@ -2111,7 +2111,7 @@
         "\n",
         "You now have a fine-tuned PaliGemma model! Next, it will be time to deploy it so we can get predictions. You will soon be able to do this in two lines of code with [Roboflow Inference](https://github.com/roboflow/inference); stay tuned for updates.\n",
         "\n",
-        "⭐️ If you enjoyed this notebook, [**star the Roboflow Notebooks repo**](https://https://github.com/roboflow/notebooks) (and [**supervision**](https://github.com/roboflow/supervision) while you're at it) and let us know what tutorials you'd like to see us do next. ⭐️"
+        "⭐️ If you enjoyed this notebook, [**star the Roboflow Notebooks repo**](https://github.com/roboflow/notebooks) (and [**supervision**](https://github.com/roboflow/supervision) while you're at it) and let us know what tutorials you'd like to see us do next. ⭐️"
       ],
       "metadata": {
         "id": "kR8llI4Qv0pR"


### PR DESCRIPTION
# Description
Incorrect Link to Roboflow Notebooks directory (https:// was used twice)

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

The link now works on being clicked

## Any specific deployment considerations

N.A

## Docs

N.A
