### PR TITLE
Setting Kaggle Credentials

### DIFF
--- a/notebooks/how-to-finetune-paligemma-on-detection-dataset.ipynb
+++ b/notebooks/how-to-finetune-paligemma-on-detection-dataset.ipynb
@@ -325,6 +325,26 @@
       ]
     },
     {
+      "cell_type": "code",
+      "source": [
+        "#If you encounter issues with the cell above, please try using this one\n",
+        "!mkdir ~/.kaggle\n",
+        "!touch ~/.kaggle/kaggle.json\n",
+        "\n",
+        "api_token = {\"username\":\"KAGGLE_USERNAME\",\"key\":\"KAGGLE_KEY\"}\n",
+        "\n",
+        "import json\n",
+        "\n",
+        "with open('/root/.kaggle/kaggle.json', 'w') as file:\n",
+        "    json.dump(api_token, file)"
+      ],
+      "metadata": {
+        "id": "Guzj8FG3QAHU"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
       "cell_type": "markdown",
       "source": [
         "### Import JAX and other dependencies\n",


### PR DESCRIPTION
# Description

The existing code in the notebook for setting Kaggle credentials uses the Colab-specific userdata.get API, which may not work outside Colab. The added method works in different environments. It simply creates a .kaggle directory and writes the API token to a kaggle.json file.

## Type of change

Please delete options that are not relevant.

-   [x] New feature (non-breaking change which adds functionality)


## How has this change been tested, please provide a testcase or example of how you tested the change?
The added cell is used to set up the Kaggle credentials to download the Paligemma model from Kaggle on Google Colab. It also works on the local machine.

## Any specific deployment considerations
N/A

## Docs

-   [ ] Docs updated? What were the changes:
