### PR TITLE
Fix duplicate https link

### DIFF
--- a/notebooks/how-to-finetune-paligemma-on-detection-dataset.ipynb
+++ b/notebooks/how-to-finetune-paligemma-on-detection-dataset.ipynb
@@ -1727,7 +1727,7 @@
       "source": [
         "# Congratulations\n",
         "\n",
-        "⭐️ If you enjoyed this notebook, [**star the Roboflow Notebooks repo**](https://https://github.com/roboflow/notebooks) (and [**supervision**](https://github.com/roboflow/supervision) while you're at it) and let us know what tutorials you'd like to see us do next. ⭐️"
+        "⭐️ If you enjoyed this notebook, [**star the Roboflow Notebooks repo**](https://github.com/roboflow/notebooks) (and [**supervision**](https://github.com/roboflow/supervision) while you're at it) and let us know what tutorials you'd like to see us do next. ⭐️"
       ],
       "metadata": {
         "id": "kR8llI4Qv0pR"


### PR DESCRIPTION
# Description

This PR fixes a link in the footer of the PaliGemma notebook from:

```
        "⭐️ If you enjoyed this notebook, [**star the Roboflow Notebooks repo**](https://https://github.com/roboflow/notebooks)
```

(notice the `https://https://`

to:

```
        "⭐️ If you enjoyed this notebook, [**star the Roboflow Notebooks repo**](https://github.com/roboflow/notebooks)
```

This is the same change proposed in #276, except the merge conflicts were too complex to merge so I have opened a new PR.

## Type of change

Link fix

## How has this change been tested, please provide a testcase or example of how you tested the change?

N/A

## Any specific deployment considerations

N/A

## Docs

N.A
