### PR TITLE
Fix: Resolve "Cannot add new object id" error in video tracking

### DIFF
--- a/notebooks/how-to-segment-videos-with-sam-2.ipynb
+++ b/notebooks/how-to-segment-videos-with-sam-2.ipynb
@@ -1137,13 +1137,15 @@
         "    ], dtype=np.float32)\n",
         "    labels = np.ones(len(points))\n",
         "\n",
-        "    _, object_ids, mask_logits = sam2_model.add_new_points(\n",
-        "        inference_state=inference_state,\n",
-        "        frame_idx=FRAME_IDX,\n",
-        "        obj_id=object_id,\n",
-        "        points=points,\n",
-        "        labels=labels,\n",
-        "    )"
+        "    sam2_model.reset_state(inference_state) 
+        "    for object_id, label in enumerate(OBJECTS, start=1):
+        "      _, object_ids, mask_logits = sam2_model.add_new_points(\n",
+        "          inference_state=inference_state,\n",
+        "          frame_idx=FRAME_IDX,\n",
+        "          obj_id=object_id,\n",
+        "          points=points,\n",
+        "          labels=labels,\n",
+        "      )"
       ],
       "metadata": {
         "id": "rpz4oKDDIevv"


### PR DESCRIPTION
The `add_new_points` method throws a RuntimeError if new objects are added after tracking has started. 
This commit resets the SAM 2 tracking state (inference_state) before adding new points, ensuring that
new objects can be defined and tracked correctly.