### PR TITLE
Yolo11 finetuning notebooks path fix for kaggle

### DIFF
--- a/notebooks/train-yolo11-object-detection-on-custom-dataset.ipynb
+++ b/notebooks/train-yolo11-object-detection-on-custom-dataset.ipynb
@@ -880,7 +880,7 @@
         "import os\n",
         "from IPython.display import Image as IPyImage, display\n",
         "\n",
-        "latest_folder = max(glob.glob('/content/runs/detect/predict*/'), key=os.path.getmtime)\n",
+        "latest_folder = max(glob.glob(f'{HOME}/runs/detect/predict*/'), key=os.path.getmtime)\n",
         "for img in glob.glob(f'{latest_folder}/*.jpg')[:3]:\n",
         "    display(IPyImage(filename=img, width=600))\n",
         "    print(\"\\n\")"


### PR DESCRIPTION
# Description

The prediction section using a custom-trained model faces one issue. The path for showing predicted results is right for Colab but not for Kaggle. So Kaggle Notebook will give errors. As we already set {HOME} in our code to get rid of this collab-kaggle problem. So this PR just fixes that; using {HOME} in the path as an f-string gives the flexibility to run the notebook in both the Colab and Kaggle environments. By the way, the Yolo11 segmentation finetune notebook actually has this code change in the prediction section.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

After making the changes, the Kaggle notebook cell was rerun and worked fine.

## Any specific deployment considerations

It is not needed, it is just a notebook code change.

## Docs

-   [ ] Docs updated? What were the changes:

cc: @SkalskiP 