### PR TITLE
fix: notebook state and object type in instructions

### DIFF
--- a/notebooks/how-to-segment-videos-with-segment-anything-3.ipynb
+++ b/notebooks/how-to-segment-videos-with-segment-anything-3.ipynb
@@ -564,7 +564,7 @@
       "source": [
         "### Adding a text prompt\n",
         "\n",
-        "Here we use the text prompt \"person\" to detect all people in the video. SAM 3 will automatically identify multiple person instances and assign each a unique object ID."
+        "Here we use the text prompt \"jet\" to detect all jets in the video. SAM 3 will automatically identify multiple jet instances and assign each a unique object ID."
       ],
       "metadata": {
         "id": "4I93bYViMBLo"
@@ -1625,7 +1625,8 @@
             "_view_name": "StyleView",
             "description_width": ""
           }
-        }
+        },
+        "state": {}
       }
     }
   },


### PR DESCRIPTION
# Description

I added an empty state to the notebook metadata after realizing GitHub was not displaying it properly: https://github.com/roboflow/notebooks/blob/c414fa8ae353ead3e289f81cb7a54fd4a18e5795/notebooks/how-to-segment-videos-with-segment-anything-3.ipynb

<img width="1119" height="433" alt="Screenshot 2025-12-04 at 14 50 19" src="https://github.com/user-attachments/assets/4dd1f0ca-1def-47f7-9835-c6e88e24f0f0" />

Google Colab notebook works properly without this update. I could run it until (excluding) `propagate in video` section with the free tier GPU. I realized the instructions say `person` where they should say `jet`. So I fixed that as well.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

The updated notebook on my fork, which gets parsed properly by GitHub, can be seen at https://github.com/furkan/notebooks/blob/e02928e3790a748aff0d9377892a4c6a5cfea32a/notebooks/how-to-segment-videos-with-segment-anything-3.ipynb

## Any specific deployment considerations

None

## Docs

Docs were not updated

---

Thank you for all the work that went into this repository.