### PR TITLE
Make RF-DETR-Medium default model used in trackers package examples.

### DIFF
--- a/notebooks/how-to-track-objects-with-deepsort-tracker.ipynb
+++ b/notebooks/how-to-track-objects-with-deepsort-tracker.ipynb
@@ -197,7 +197,7 @@
         "from inference import get_model\n",
         "from trackers import DeepSORTFeatureExtractor, DeepSORTTracker\n",
         "\n",
-        "model = get_model(\"yolov8m-640\")\n",
+        "model = get_model(\"rfdetr-medium\")\n",
         "\n",
         "feature_extractor = DeepSORTFeatureExtractor.from_timm(\n",
         "    model_name=\"mobilenetv4_conv_small.e1200_r224_in1k\")\n",

--- a/notebooks/how-to-track-objects-with-sort-tracker.ipynb
+++ b/notebooks/how-to-track-objects-with-sort-tracker.ipynb
@@ -183,7 +183,7 @@
         "from inference import get_model\n",
         "from trackers import SORTTracker\n",
         "\n",
-        "model = get_model(\"yolov8m-640\")\n",
+        "model = get_model(\"rfdetr-medium\")\n",
         "tracker = SORTTracker()"
       ],
       "metadata": {


### PR DESCRIPTION
## What does this PR do?

Make RF-DETR-Medium default model used in trackers package examples.

## Type of Change

New feature (non-breaking change that adds functionality)

## Testing

- [x] I have tested this change locally
- [ ] I have added/updated tests for this change

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)