### PR TITLE
Add Open in Colab badge to GLM-OCR notebook

### DIFF
--- a/notebooks/how-to-perform-ocr-with-glm-ocr.ipynb
+++ b/notebooks/how-to-perform-ocr-with-glm-ocr.ipynb
@@ -12,7 +12,7 @@
         "\n",
         "---\n",
         "\n",
-        "[![arXiv](https://img.shields.io/badge/arXiv-2603.10910-b31b1b.svg)](https://arxiv.org/abs/2603.10910)\n",
+        "[![colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/roboflow-ai/notebooks/blob/main/notebooks/how-to-perform-ocr-with-glm-ocr.ipynb)\n[![arXiv](https://img.shields.io/badge/arXiv-2603.10910-b31b1b.svg)](https://arxiv.org/abs/2603.10910)\n",
         "\n",
         "[GLM-OCR](https://huggingface.co/zai-org/GLM-OCR) is a 0.9B-parameter\n",
         "vision-language model built for optical character recognition. It scores\n",


### PR DESCRIPTION
## Summary
- Add missing "Open in Colab" badge to `how-to-perform-ocr-with-glm-ocr.ipynb` header cell, consistent with all other notebooks in the repo