### PR TITLE
Fix Qwen2.5-VL notebook supervision dependency pin

### DIFF
--- a/notebooks/zero-shot-object-detection-with-qwen2-5-vl.ipynb
+++ b/notebooks/zero-shot-object-detection-with-qwen2-5-vl.ipynb
@@ -133,7 +133,7 @@
       "outputs": [],
       "source": [
         "!pip install -q \"maestro[qwen_2_5_vl]==1.1.0rc2\"\n",
-        "!pip install -q supervision==0.26.0"
+        "!pip install -q supervision==0.25.1"
       ]
     },
     {


### PR DESCRIPTION
## Summary

- Pins the Qwen2.5-VL notebook to supervision==0.25.1.
- Keeps the pin within maestro==1.1.0rc2's declared supervision>=0.20.0,<0.26.0 dependency range.
- Addresses the dependency resolver conflict reported in #368.

## Validation

- Parsed 
otebooks/zero-shot-object-detection-with-qwen2-5-vl.ipynb as JSON.
- Confirmed the install cell now uses maestro[qwen_2_5_vl]==1.1.0rc2 with supervision==0.25.1.
- Ran pip dry-run resolution with Python 3.12: maestro[qwen_2_5_vl]==1.1.0rc2 + supervision==0.25.1 resolves successfully.
- Confirmed the previous supervision==0.26.0 pin fails because maestro==1.1.0rc2 requires supervision<0.26.0.

Fixes #368.
