### PR TITLE
fix: install rfdetr train extras in RF-DETR finetuning notebooks

### DIFF
--- a/notebooks/how-to-finetune-rf-detr-on-detection-dataset.ipynb
+++ b/notebooks/how-to-finetune-rf-detr-on-detection-dataset.ipynb
@@ -146,7 +146,7 @@
     {
       "cell_type": "code",
       "source": [
-        "!pip install -q rfdetr>=1.4.0 supervision roboflow"
+        "!pip install -q \"rfdetr[train,loggers]>=1.4.0\" roboflow \"supervision==0.29.1\""
       ],
       "metadata": {
         "id": "3CbzMY6wITlr"

--- a/notebooks/how-to-finetune-rf-detr-on-segmentation-dataset.ipynb
+++ b/notebooks/how-to-finetune-rf-detr-on-segmentation-dataset.ipynb
@@ -134,7 +134,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install -q rfdetr>=1.4.0 supervision roboflow"
+        "!pip install -q \"rfdetr[train,loggers]>=1.4.0\" roboflow \"supervision==0.29.1\""
       ]
     },
     {


### PR DESCRIPTION
## Problem

On a fresh Colab run, the training cell in both RF-DETR finetuning notebooks fails:

```
ImportError: RF-DETR training dependencies are missing. Install them with `pip install "rfdetr[train,loggers]"` and try again.
```

Two causes:
1. Newer `rfdetr` releases (current: 1.8.3) moved training dependencies (`pytorch_lightning`, `torchmetrics`, `pycocotools`, etc.) into the optional `[train]` extra, so the plain `rfdetr` install can no longer train.
2. The existing install line `!pip install -q rfdetr>=1.4.0 ...` is unquoted, so the shell treats `>=1.4.0` as an output redirect — the version constraint was never actually applied and Colab always pulled the latest release.

## Fix

```
!pip install -q "rfdetr[train,loggers]>=1.4.0" roboflow "supervision==0.29.1"
```

- `[train]` restores the training dependencies; `[loggers]` matches the package's own error message and keeps default TensorBoard logging working outside Colab.
- Quoting makes the `>=1.4.0` floor actually apply.
- `supervision` is pinned to `0.29.1`, following the pattern in the newer `rf-detr-keypoint-detection.ipynb`, to prevent the same class of drift from the annotator API.

## Notebooks changed

- `notebooks/how-to-finetune-rf-detr-on-detection-dataset.ipynb`
- `notebooks/how-to-finetune-rf-detr-on-segmentation-dataset.ipynb`

Both verified end-to-end on fresh Colab runs (training now completes).

Note: `nvidia-launchables/how-to-finetune-rf-detr-on-segmentation-dataset-a100.ipynb` still pins `rfdetr==1.3.0` (pre-extras split, so not broken today) — left untouched since updating it would need an A100 retest.