### PR TITLE
fix: migrate version.model usage to version.models() for roboflow 1.4.0

### DIFF
--- a/notebooks/roboflow_video_inference_with_custom_annotators.ipynb
+++ b/notebooks/roboflow_video_inference_with_custom_annotators.ipynb
@@ -158,7 +158,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": null,
       "metadata": {
         "id": "CL4gVrnl9dmR",
         "colab": {
@@ -166,16 +166,7 @@
         },
         "outputId": "225c7f8b-4a22-48f2-e096-886d1ca71c88"
       },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "loading Roboflow workspace...\n",
-            "loading Roboflow project...\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "PROJECT_NAME = \"logistics-sz9jr\"\n",
         "VIDEO_FILE = \"example.mp4\"\n",
@@ -183,7 +174,8 @@
         "\n",
         "rf = Roboflow(api_key=\"UhiOc8NF1s2pYjp0zN3Q\")\n",
         "project = rf.workspace().project(PROJECT_NAME)\n",
-        "model = project.version(2).model\n",
+        "# As of roboflow 1.4.0 a version can own multiple models; models() lists them, newest first\n",
+        "model = project.version(2).models()[0]\n",
         "\n",
         "job_id, signed_url, expire_time = model.predict_video(\n",
         "    VIDEO_FILE,\n",

--- a/notebooks/train-yolov8-classification-on-custom-dataset.ipynb
+++ b/notebooks/train-yolov8-classification-on-custom-dataset.ipynb
@@ -972,7 +972,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 38,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -980,44 +980,14 @@
         "id": "xiq9pDVwRerQ",
         "outputId": "4eebe6d4-473a-4dc4-f0a2-2476b147ced4"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "running inference on /content/datasets/banana-ripeness-classification-1/test/rotten/musa-acuminata-banana-a4d2539a-394a-11ec-b89e-d8c4975e38aa_jpg.rf.5619acd86fab49bfc9f79bff1a4bc8df.jpg\n"
-          ]
-        },
-        {
-          "data": {
-            "text/plain": [
-              "{'predictions': [{'inference_id': '73e211ac-ffa8-4f4e-8fca-62d0e97074ec',\n",
-              "   'time': 0.006123511999703624,\n",
-              "   'image': {'width': 416, 'height': 416},\n",
-              "   'predictions': [{'class': 'unripe', 'class_id': 5, 'confidence': 0.2281},\n",
-              "    {'class': 'rotten', 'class_id': 4, 'confidence': 0.213},\n",
-              "    {'class': 'ripe', 'class_id': 3, 'confidence': 0.1415},\n",
-              "    {'class': 'freshunripe', 'class_id': 1, 'confidence': 0.1402},\n",
-              "    {'class': 'overripe', 'class_id': 2, 'confidence': 0.1396},\n",
-              "    {'class': 'freshripe', 'class_id': 0, 'confidence': 0.1377}],\n",
-              "   'top': 'unripe',\n",
-              "   'confidence': 0.2281,\n",
-              "   'image_path': '/content/datasets/banana-ripeness-classification-1/test/rotten/musa-acuminata-banana-a4d2539a-394a-11ec-b89e-d8c4975e38aa_jpg.rf.5619acd86fab49bfc9f79bff1a4bc8df.jpg',\n",
-              "   'prediction_type': 'ClassificationModel'}],\n",
-              " 'image': (416, 416)}"
-            ]
-          },
-          "execution_count": 38,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "# Run inference on your model on a persistant, auto-scaling, cloud API\n",
         "\n",
-        "# Load model\n",
-        "model = project.version(dataset.version).model\n",
-        "assert model, \"Model deployment is still loading\"\n",
+        "# Load model (as of roboflow 1.4.0 a version can own multiple models, so we list them and take the newest)\n",
+        "models = project.version(dataset.version).models()\n",
+        "assert models, \"Model deployment is still loading\"\n",
+        "model = models[0]\n",
         "\n",
         "# Choose a random test image\n",
         "import os, random, glob\n",

--- a/notebooks/train-yolov8-keypoint.ipynb
+++ b/notebooks/train-yolov8-keypoint.ipynb
@@ -664,7 +664,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -672,82 +672,8 @@
     "id": "e96p36aai07K",
     "outputId": "ec273efd-5276-412f-bc71-c838f8dc0e2c"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "running inference on IMG_4837_JPG.rf.6462a662cb217bacd93d1de1f4458e51.jpg\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "{'predictions': [{'inference_id': 'b7b62f0d-3a71-46d1-ae90-bab728fe7ab0',\n",
-       "   'time': 0.03955303400016419,\n",
-       "   'image': {'width': 640, 'height': 640},\n",
-       "   'predictions': [{'x': 113.5,\n",
-       "     'y': 184.5,\n",
-       "     'width': 155.0,\n",
-       "     'height': 277.0,\n",
-       "     'confidence': 0.7923569679260254,\n",
-       "     'class': 'glue',\n",
-       "     'class_id': 0,\n",
-       "     'detection_id': 'cd9edf4e-4173-4804-9262-badacd7dd426',\n",
-       "     'keypoints': [{'x': 156.0,\n",
-       "       'y': 107.0,\n",
-       "       'confidence': 0.9488583207130432,\n",
-       "       'class_id': 0,\n",
-       "       'class_name': '0'},\n",
-       "      {'x': 48.0,\n",
-       "       'y': 292.0,\n",
-       "       'confidence': 0.87955641746521,\n",
-       "       'class_id': 1,\n",
-       "       'class_name': '1'}]},\n",
-       "    {'x': 515.0,\n",
-       "     'y': 339.0,\n",
-       "     'width': 122.0,\n",
-       "     'height': 300.0,\n",
-       "     'confidence': 0.6757180690765381,\n",
-       "     'class': 'glue',\n",
-       "     'class_id': 0,\n",
-       "     'detection_id': '734718ca-0489-4af9-aa99-80e6aad21277',\n",
-       "     'keypoints': [{'x': 549.0,\n",
-       "       'y': 215.0,\n",
-       "       'confidence': 0.9749020338058472,\n",
-       "       'class_id': 0,\n",
-       "       'class_name': '0'},\n",
-       "      {'x': 468.0,\n",
-       "       'y': 469.0,\n",
-       "       'confidence': 0.9157001376152039,\n",
-       "       'class_id': 1,\n",
-       "       'class_name': '1'}]}],\n",
-       "   'image_path': '/content/datasets/glue-tube-keypoints-1/test/images/IMG_4837_JPG.rf.6462a662cb217bacd93d1de1f4458e51.jpg',\n",
-       "   'prediction_type': 'ClassificationModel'}],\n",
-       " 'image': (640, 640)}"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Run inference on your model on a persistant, auto-scaling, cloud API\n",
-    "\n",
-    "# Load model\n",
-    "model = project.version(dataset.version).model\n",
-    "assert model, \"Model deployment is still loading\"\n",
-    "\n",
-    "# Choose a random test image\n",
-    "import os, random\n",
-    "test_set_loc = dataset.location + \"/test/images/\"\n",
-    "random_test_image = random.choice(os.listdir(test_set_loc))\n",
-    "print(\"running inference on \" + random_test_image)\n",
-    "\n",
-    "pred = model.predict(test_set_loc + random_test_image).json()\n",
-    "pred"
-   ]
+   "outputs": [],
+   "source": "# Run inference on your model on a persistant, auto-scaling, cloud API\n\n# Load model (as of roboflow 1.4.0 a version can own multiple models, so we list them and take the newest)\nmodels = project.version(dataset.version).models()\nassert models, \"Model deployment is still loading\"\nmodel = models[0]\n\n# Choose a random test image\nimport os, random\ntest_set_loc = dataset.location + \"/test/images/\"\nrandom_test_image = random.choice(os.listdir(test_set_loc))\nprint(\"running inference on \" + random_test_image)\n\npred = model.predict(test_set_loc + random_test_image).json()\npred"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
> [!NOTE]
> _Code and PR description are LLM-written. Code has been reviewed and tested in staging by Kai_

## Why

`roboflow-python` 1.4.0 (the MMPV release — a dataset version can now own multiple trained models) deprecated the singular `version.model` attribute in favor of `version.models()`. Two consequences for this repo:

1. **Deprecation noise:** every notebook that touches `version.model` now prints a `DeprecationWarning` to users.
2. **Latent breakage:** `version.model` is derived from the `model` field on the project payload's version entry, which is absent for versions whose models were trained through the v2 trainings pipeline. For those versions `version.model` returns `None` even when trained models exist (verified against staging: 1.3.13 returns a working model object for `kaiplace/the-paid-gallery/187`, 1.4.0 returns `None`, while `version.models()` correctly lists 5 models). The demo versions these notebooks point at are legacy-trained, so they still work today — but they will break silently (`assert model, "Model deployment is still loading"`) once retrained through the new pipeline, and the pattern already breaks for any user following along with their own v2-trained version.

## What

Migrates the three unpinned notebooks that used `version.model` to the new canonical `version.models()` API (newest model first; `TrainedModel` supports the same `.predict()` / `.predict_video()` / `.poll_until_video_results()` calls):

- `notebooks/train-yolov8-keypoint.ipynb`
- `notebooks/train-yolov8-classification-on-custom-dataset.ipynb`
- `notebooks/roboflow_video_inference_with_custom_annotators.ipynb`

Outputs of the edited cells were cleared (they showed output from the old API, including the since-fixed `prediction_type: 'ClassificationModel'` mislabel on keypoint predictions).

Not touched: notebooks pinned to `roboflow==1.1.48`/`1.1.49` (insulated from 1.4.0), and `train-package-detector-two-labeled-images.ipynb` (`version.train()` still works unchanged).

## Related

The higher-leverage fix is arguably in `roboflow-python` itself: the deprecated `version.model` shim could fall back to the v2 surface when the legacy payload field is missing, which would un-break all existing content (docs, blogs, customer code) rather than just this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)