### PR TITLE
Add suggestion to uninstall `torchaudio` in order to make clean installation of inference

### DIFF
--- a/notebooks/basketball-ai-automatic-detection-of-3-second-violations.ipynb
+++ b/notebooks/basketball-ai-automatic-detection-of-3-second-violations.ipynb
@@ -160,6 +160,10 @@
     {
       "cell_type": "code",
       "source": [
+        "# Since end of Jul 2026, inference clashes with Google Colab environment regarding torchaudio. If you experience a problem with imports, \n",
+        "# we suggest uninstalling torchaudio package and restarting the runtime.\n",
+        "!pip uninstall -y torchaudio\n",
+        "\n",
         "!pip install -q gdown transformers\n",
         "!pip install -q inference-gpu\n",
         "!pip install -q git+https://github.com/roboflow/supervision.git@feature/advanced_keypoints_indexing_and_slicing\n",

--- a/notebooks/basketball-ai-make-or-miss-jumpshot-detection.ipynb
+++ b/notebooks/basketball-ai-make-or-miss-jumpshot-detection.ipynb
@@ -171,6 +171,10 @@
     {
       "cell_type": "code",
       "source": [
+        "# Since end of Jul 2026, inference clashes with Google Colab environment regarding torchaudio. If you experience a problem with imports, \n",
+        "# we suggest uninstalling torchaudio package and restarting the runtime.\n",
+        "!pip uninstall -y torchaudio\n",
+        "\n",
         "!pip install -q gdown\n",
         "!pip install -q inference-gpu\n",
         "!pip install -q git+https://github.com/roboflow/supervision.git\n",

--- a/notebooks/football-ai.ipynb
+++ b/notebooks/football-ai.ipynb
@@ -130,6 +130,10 @@
       },
       "outputs": [],
       "source": [
+        "# Since end of Jul 2026, inference clashes with Google Colab environment regarding torchaudio. If you experience a problem with imports, \n",
+        "# we suggest uninstalling torchaudio package and restarting the runtime.\n",
+        "!pip uninstall -y torchaudio\n",
+        "\n",
         "!pip install -q gdown inference-gpu"
       ]
     },

--- a/notebooks/how-to-finetune-florence-2-on-detection-dataset.ipynb
+++ b/notebooks/how-to-finetune-florence-2-on-detection-dataset.ipynb
@@ -5241,6 +5241,10 @@
     {
       "cell_type": "code",
       "source": [
+        "# Since end of Jul 2026, inference clashes with Google Colab environment regarding torchaudio. If you experience a problem with imports, \n",
+        "# we suggest uninstalling torchaudio package and restarting the runtime.\n",
+        "!pip uninstall -y torchaudio\n",
+        "\n",
         "!pip install inference"
       ],
       "metadata": {

--- a/notebooks/how-to-finetune-rf-detr-on-detection-dataset.ipynb
+++ b/notebooks/how-to-finetune-rf-detr-on-detection-dataset.ipynb
@@ -1413,6 +1413,10 @@
     {
       "cell_type": "code",
       "source": [
+        "# Since end of Jul 2026, inference clashes with Google Colab environment regarding torchaudio. If you experience a problem with imports, \n",
+        "# we suggest uninstalling torchaudio package and restarting the runtime.\n",
+        "!pip uninstall -y torchaudio\n",
+        "\n",
         "!pip install -q inference"
       ],
       "metadata": {

--- a/notebooks/how-to-finetune-rf-detr-on-segmentation-dataset.ipynb
+++ b/notebooks/how-to-finetune-rf-detr-on-segmentation-dataset.ipynb
@@ -1359,6 +1359,10 @@
       },
       "outputs": [],
       "source": [
+        "# Since end of Jul 2026, inference clashes with Google Colab environment regarding torchaudio. If you experience a problem with imports, \n",
+        "# we suggest uninstalling torchaudio package and restarting the runtime.\n",
+        "!pip uninstall -y torchaudio\n",
+        "\n",
         "!pip install -q inference"
       ]
     },

--- a/notebooks/how-to-track-objects-with-bytetrack-tracker.ipynb
+++ b/notebooks/how-to-track-objects-with-bytetrack-tracker.ipynb
@@ -92,6 +92,10 @@
     "id": "VUXr5x_sQ5CT"
    },
    "source": [
+    "# Since end of Jul 2026, inference clashes with Google Colab environment regarding torchaudio. If you experience a problem with imports, \n",
+    "# we suggest uninstalling torchaudio package and restarting the runtime.\n",
+    "!pip uninstall -y torchaudio\n",
+    "\n",
     "!pip install -q inference-gpu trackers==2.3.0"
    ],
    "execution_count": null,

--- a/notebooks/how-to-track-objects-with-deepsort-tracker.ipynb
+++ b/notebooks/how-to-track-objects-with-deepsort-tracker.ipynb
@@ -117,6 +117,10 @@
     {
       "cell_type": "code",
       "source": [
+        "# Since end of Jul 2026, inference clashes with Google Colab environment regarding torchaudio. If you experience a problem with imports, \n",
+        "# we suggest uninstalling torchaudio package and restarting the runtime.\n",
+        "!pip uninstall -y torchaudio\n",
+        "\n",
         "!pip install -q inference-gpu\n",
         "!pip install -q trackers[deepsort]\n",
         "!pip install -q supervision==0.27.0rc1"

--- a/notebooks/how-to-track-objects-with-ocsort-tracker.ipynb
+++ b/notebooks/how-to-track-objects-with-ocsort-tracker.ipynb
@@ -92,6 +92,10 @@
     "id": "VUXr5x_sQ5CT"
    },
    "source": [
+    "# Since end of Jul 2026, inference clashes with Google Colab environment regarding torchaudio. If you experience a problem with imports, \n",
+    "# we suggest uninstalling torchaudio package and restarting the runtime.\n",
+    "!pip uninstall -y torchaudio\n",
+    "\n",
     "!pip install -q inference-gpu trackers==2.3.0"
    ],
    "execution_count": null,

--- a/notebooks/how-to-track-objects-with-sort-tracker.ipynb
+++ b/notebooks/how-to-track-objects-with-sort-tracker.ipynb
@@ -50,6 +50,10 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
+        "# Since end of Jul 2026, inference clashes with Google Colab environment regarding torchaudio. If you experience a problem with imports, \n",
+        "# we suggest uninstalling torchaudio package and restarting the runtime.\n",
+        "!pip uninstall -y torchaudio\n",
+        "\n",
         "!pip install -q inference-gpu trackers==2.3.0"
       ],
       "execution_count": null,

--- a/notebooks/nvidia-launchables/how-to-finetune-rf-detr-on-segmentation-dataset-a100.ipynb
+++ b/notebooks/nvidia-launchables/how-to-finetune-rf-detr-on-segmentation-dataset-a100.ipynb
@@ -689,6 +689,10 @@
       },
       "outputs": [],
       "source": [
+        "# Since end of Jul 2026, inference clashes with Google Colab environment regarding torchaudio. If you experience a problem with imports, \n",
+        "# we suggest uninstalling torchaudio package and restarting the runtime.\n",
+        "!pip uninstall -y torchaudio\n",
+        "\n",
         "!pip install -q inference-gpu==0.58.1"
       ]
     },

--- a/notebooks/train-yolo11-object-detection-on-custom-dataset.ipynb
+++ b/notebooks/train-yolo11-object-detection-on-custom-dataset.ipynb
@@ -920,6 +920,10 @@
       },
       "outputs": [],
       "source": [
+        "# Since end of Jul 2026, inference clashes with Google Colab environment regarding torchaudio. If you experience a problem with imports, \n",
+        "# we suggest uninstalling torchaudio package and restarting the runtime.\n",
+        "!pip uninstall -y torchaudio\n",
+        "\n",
         "!pip install inference"
       ]
     },

--- a/notebooks/train-yolo26-instance-segmentation-on-custom-dataset.ipynb
+++ b/notebooks/train-yolo26-instance-segmentation-on-custom-dataset.ipynb
@@ -1334,6 +1334,10 @@
     {
       "cell_type": "code",
       "source": [
+        "# Since end of Jul 2026, inference clashes with Google Colab environment regarding torchaudio. If you experience a problem with imports, \n",
+        "# we suggest uninstalling torchaudio package and restarting the runtime.\n",
+        "!pip uninstall -y torchaudio\n",
+        "\n",
         "!pip install -q inference"
       ],
       "metadata": {

--- a/notebooks/train-yolo26-object-detection-on-custom-dataset.ipynb
+++ b/notebooks/train-yolo26-object-detection-on-custom-dataset.ipynb
@@ -1195,6 +1195,10 @@
     {
       "cell_type": "code",
       "source": [
+        "# Since end of Jul 2026, inference clashes with Google Colab environment regarding torchaudio. If you experience a problem with imports, \n",
+        "# we suggest uninstalling torchaudio package and restarting the runtime.\n",
+        "!pip uninstall -y torchaudio\n",
+        "\n",
         "!pip install -q inference"
       ],
       "metadata": {

--- a/notebooks/train_yolo11_instance_segmentation_on_custom_dataset.ipynb
+++ b/notebooks/train_yolo11_instance_segmentation_on_custom_dataset.ipynb
@@ -1719,6 +1719,10 @@
         }
       ],
       "source": [
+        "# Since end of Jul 2026, inference clashes with Google Colab environment regarding torchaudio. If you experience a problem with imports, \n",
+        "# we suggest uninstalling torchaudio package and restarting the runtime.\n",
+        "!pip uninstall -y torchaudio\n",
+        "\n",
         "!pip install inference"
       ]
     },

--- a/notebooks/zero-shot-object-detection-with-yolo-world.ipynb
+++ b/notebooks/zero-shot-object-detection-with-yolo-world.ipynb
@@ -138,6 +138,10 @@
     {
       "cell_type": "code",
       "source": [
+        "# Since end of Jul 2026, inference clashes with Google Colab environment regarding torchaudio. If you experience a problem with imports, \n",
+        "# we suggest uninstalling torchaudio package and restarting the runtime.\n",
+        "!pip uninstall -y torchaudio\n",
+        "\n",
         "!pip install -q inference-gpu[yolo-world]==0.9.13"
       ],
       "metadata": {


### PR DESCRIPTION
## What does this PR do?

Discovered a problem with `inference` which pushes `torch` change to current Google Colab environment - but w/o ability to override existing `torchaudio` installation - causing version clash. In this PR, each place where `inference` is installed, there is a suggestion to remove stale `torchaudio` before installing `inference`.

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)

## Testing

<!-- Describe how you tested your changes -->
- tested installation and fix in clean Google Colab env.
- [ ] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
